### PR TITLE
Fix docker collector verbose timeout

### DIFF
--- a/src/collectors/docker_collector/docker_collector.py
+++ b/src/collectors/docker_collector/docker_collector.py
@@ -67,52 +67,48 @@ class DockerCollector(diamond.collector.Collector):
         if docker is None:
             self.log.error('Unable to import docker')
 
-        try:
-            # Collect info
-            results = {}
-            client = docker.Client(version='auto')
+        # Collect info
+        results = {}
+        client = docker.Client(version='auto')
 
-            # Top level stats
-            running_containers = client.containers()
-            results['containers_running_count'] = (
-                len(running_containers), 'GAUGE')
+        # Top level stats
+        running_containers = client.containers()
+        results['containers_running_count'] = (
+            len(running_containers), 'GAUGE')
 
-            all_containers = client.containers(all=True)
-            results['containers_stopped_count'] = (
-                len(all_containers) - len(running_containers), 'GAUGE')
+        all_containers = client.containers(all=True)
+        results['containers_stopped_count'] = (
+            len(all_containers) - len(running_containers), 'GAUGE')
 
-            images_count = len(set(client.images(quiet=True)))
-            results['images_count'] = (images_count, 'GAUGE')
+        images_count = len(set(client.images(quiet=True)))
+        results['images_count'] = (images_count, 'GAUGE')
 
-            dangling_images_count = len(set(client.images(
-                quiet=True, all=True, filters={'dangling': True})))
-            results['images_dangling_count'] = (dangling_images_count, 'GAUGE')
+        dangling_images_count = len(set(client.images(
+            quiet=True, all=True, filters={'dangling': True})))
+        results['images_dangling_count'] = (dangling_images_count, 'GAUGE')
 
-            # Collect memory and cpu stats
-            for container in running_containers:
-                # build namespace from configured labels
-                values = [container['Labels'].get(l) for l in self.config['labels']]
-                label = ".".join([v for v in values if v is not None])
+        # Collect memory and cpu stats
+        for container in running_containers:
+            # build namespace from configured labels
+            values = [container['Labels'].get(l) for l in self.config['labels']]
+            label = ".".join([v for v in values if v is not None])
 
-                # prepend namespace created from labels with container name
-                prefix = ["containers", container['Names'][0][1:]]
-                if label != '':
-                    prefix.append(label)
+            # prepend namespace created from labels with container name
+            prefix = ["containers", container['Names'][0][1:]]
+            if label != '':
+                prefix.append(label)
 
-                namespace = ".".join(prefix)
+            namespace = ".".join(prefix)
 
-                s = client.stats(container["Id"])
-                stat = json.loads(s.next())
-                for path in self.METRICS:
-                    val = self.get_value(path, stat)
-                    if val is not None:
-                        metric_key = ".".join([namespace, self.METRICS.get(path)])
-                        results[metric_key] = (val, 'GAUGE')
-                s.close()
+            s = client.stats(container["Id"])
+            stat = json.loads(s.next())
+            for path in self.METRICS:
+                val = self.get_value(path, stat)
+                if val is not None:
+                    metric_key = ".".join([namespace, self.METRICS.get(path)])
+                    results[metric_key] = (val, 'GAUGE')
+            s.close()
 
-            for name in sorted(results.keys()):
-                (value, metric_type) = results[name]
-                self.publish(name, value, metric_type=metric_type)
-
-        except Exception, e:
-            self.log.error(e, exc_info=True)
+        for name in sorted(results.keys()):
+            (value, metric_type) = results[name]
+            self.publish(name, value, metric_type=metric_type)


### PR DESCRIPTION
SIGALRMException was handled on the collector level, resulting in a long stacktrace printed. Scheduler already takes care of exceptions coming from collector, so removing it from DockerCollector.
